### PR TITLE
fix(ChartModal): :bug: Display descriptive error message if selected correlation fields do not contain all numeric values

### DIFF
--- a/src/Components/Chart.svelte
+++ b/src/Components/Chart.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { DateTime } from "obsidian-dataview";
-	import { getPearsonCorrelation } from "src/analyses";
+	import { getPearsonCorrelation, isQuant } from "src/analyses";
 	import { ChartModal } from "src/ChartModal";
 	import Scatter from "svelte-chartjs/src/Scatter.svelte";
 	import ChartOptions from "./ChartOptions.svelte";
@@ -19,6 +19,7 @@
 	let startDate = index.minDate;
 	let endDate = index.maxDate;
 	let dnOnly = false;
+	let errorMessage = "";
 
 	interface Datum2d {
 		x: number;
@@ -65,7 +66,15 @@
 		const xs = innerData.map((p) => p.x);
 		const ys = innerData.map((p) => p.y);
 
-		return isValidSelection(f1, f2) ? getPearsonCorrelation(xs, ys) : null;
+		if (isValidSelection(f1, f2)) {
+			const xValid = isQuant(xs)
+			const yValid = isQuant(ys)
+			errorMessage = !xValid ? "First parameter has non-numeric values" : errorMessage
+			errorMessage = !yValid ? "Second parameter has non-numeric values" : errorMessage
+			return xValid && yValid ? getPearsonCorrelation(xs, ys, true) : null
+		}
+
+		return null;
 	}
 
 	function refreshChartData(colour: string, innerData: Datum2d[]) {
@@ -153,7 +162,9 @@
 <Scatter {data} options={chartOptions} />
 
 <div class="measures">
-	{#if isValidSelection(f1, f2)}
+	{#if errorMessage != ""}
+		<span>Error: {errorMessage}</span>
+	{:else if isValidSelection(f1, f2)}
 		<span>
 			<span class="measure-name">n:</span>
 			<span class="measure-value">{innerData.length}</span>

--- a/src/analyses.ts
+++ b/src/analyses.ts
@@ -7,14 +7,14 @@
 export function getPearsonCorrelation(
 	xs: number[],
 	ys: number[],
-	skipTest = false
+	skipQuantCheck = false
 ) {
+	if (xs.length <= 1 || ys.length <= 1)
+		return null;
+
 	if (
-		xs.length <= 1 ||
-		ys.length <= 1 ||
-		skipTest ||
-		!isQuant(xs) ||
-		!isQuant(ys)
+		!skipQuantCheck &&
+		(!isQuant(xs) || !isQuant(ys))
 	)
 		return null;
 


### PR DESCRIPTION
Added a check to ensure that if user selected a field for the correlation chart modal and the field did not pass the "isQuant" check, a descriptive error is displayed

Closes issue #13