### PR TITLE
fix(ChartModal): :bug: Display descriptive error message if selected …

### DIFF
--- a/src/analyses.ts
+++ b/src/analyses.ts
@@ -7,14 +7,14 @@
 export function getPearsonCorrelation(
 	xs: number[],
 	ys: number[],
-	skipTest = false
+	skipQuantCheck = false
 ) {
+	if (xs.length <= 1 || ys.length <= 1)
+		return null;
+
 	if (
-		xs.length <= 1 ||
-		ys.length <= 1 ||
-		skipTest ||
-		!isQuant(xs) ||
-		!isQuant(ys)
+		!skipQuantCheck &&
+		(!isQuant(xs) || !isQuant(ys))
 	)
 		return null;
 


### PR DESCRIPTION
…correlation fields do not contain all numeric values

Added a check to ensure that if user selected a field for the correlation chart modal and the field did not pass the "isQuant" check, a descriptive error is displayed

Closes #13

![Screenshot](https://user-images.githubusercontent.com/86222728/148628540-756c968b-237a-4c10-aa10-41b002d7947f.png)